### PR TITLE
Bugfix: environment installation was not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Environment
 RetroPy uses FEniCS-dolfinx 0.10.0 and Reaktoro v2. Navigate to the RetroPy folder. The environment can be installed using conda:
 ```
-conda create -f environment.yml
+conda env create -f environment.yml
 conda activate fenicsx-env
 ```
 We proceed with installing [Reaktoro](https://reaktoro.org/installation/installation-using-cmake.html)

--- a/environment.yml
+++ b/environment.yml
@@ -39,7 +39,7 @@ dependencies:
 - h5py
 - pytensor
 - openmpi
-- "blas=*=accelerate"
+- blas
 - pip:
   - oyaml
 environment: {}

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ dependencies:
 - autodiff >=1.1.1
 - catch2 =2
 - ccache
-- clangxx_osx-arm64 =19
+- clangxx =19
 - cmake
 - cpp-tabulate
 - eigen


### PR DESCRIPTION
- there was a forgotten `env` missing in the command given by the README (`conda create` does not accept YAML files, and `-f` would mean `--force` instead of `--file`, thus that command crashes) 
- `blas[build=accelerate]` causes `PackagesNotFoundError: The following packages are not available from current channels` for channel `conda-forge` for conda 26.1.0
- with the changes from this pull request, environment installation works for me